### PR TITLE
Fix SEQ length in decrypt_packet

### DIFF
--- a/csrmesh/crypto.py
+++ b/csrmesh/crypto.py
@@ -18,21 +18,32 @@ def generate_key(binary):
     return bytes(dig)[:16]
 
 def make_packet(key,seq,data):
-    magic = b'\x80'
+    #Message source is always 0x0080 (32768) when sending
+    #packets from a device without a network ID
+    source = 32768
     eof = b'\xff'
     dlen = len(data)
+    seq_arr = int.to_bytes(seq, 3, byteorder="little")
     #Compute 128 bit IV based on the sequence number/nonce
-    iv = struct.pack("<Ixc10x",seq,magic)
+    #|   SEQ   |  0x00  | Source  | 0x00 x10 |
+    #| 3 bytes | 1 byte | 2 bytes | 10 bytes |
+    iv = struct.pack("<3sxH10x",seq_arr,source)
     #Initialize AES in OFB mode with the IV we just computed
     enc = AES.new(key, AES.MODE_OFB, iv)
     payload = bytearray(enc.encrypt(data))
     #Now pad, combine with header and compute HMAC
-    prehmac = struct.pack("<8xIc"+str(dlen)+"s",seq,magic,bytes(payload))
+    #HMAC Input
+    #| 0x00 x8 |   SEQ   | Source  | payload |
+    #| 8 bytes | 3 bytes | 2 bytes |   var   |
+    prehmac = struct.pack("<8x3sH"+str(dlen)+"s",seq_arr,source,bytes(payload))
     hm = bytearray(hmac.new(key, msg=prehmac, digestmod=hashlib.sha256).digest())
     #Reverse the order of the bytes and truncate
     hm.reverse()
     hm = bytes(hm)[:8]
-    final = struct.pack("<Ic"+str(dlen)+"s8sc",seq,magic,bytes(payload),hm,eof)
+    #CSR Message Format
+    #|   SEQ   | Source  | payload |  HMAC   |  EOF   |
+    #| 3 bytes | 2 bytes |   var   | 8 bytes | 1 byte |
+    final = struct.pack("<3sH"+str(dlen)+"s8sc",seq_arr,source,bytes(payload),hm,eof)
     return final
 
 def decrypt_packet(key, data):
@@ -40,20 +51,21 @@ def decrypt_packet(key, data):
         return None
     od = {}
     dlen = len(data)-14
-    (seq, magic, epayload, hmac_packet, eof) = struct.unpack("<Ic"+str(dlen)+"s8sc", data)
+    (seq_arr, source, epayload, hmac_packet, eof) = struct.unpack("<3sH"+str(dlen)+"s8sc", data)
     #Pad, combine with header and compute HMAC
-    prehmac = struct.pack("<8xIc"+str(len(epayload))+"s",seq,magic,epayload)
+    prehmac = struct.pack("<8x3sH"+str(len(epayload))+"s",seq_arr,source,epayload)
     hm = bytearray(hmac.new(key, msg=prehmac, digestmod=hashlib.sha256).digest())
     #Reverse the order of the bytes and truncate
     hm.reverse()
     hmac_computed = bytes(hm)[:8]
     #Compute the IV and initialize AES context
-    iv = struct.pack("<Ixc10x",seq,magic)
+    iv = struct.pack("<3sxH10x",seq_arr,source)
     enc = AES.new(key, AES.MODE_OFB, iv)
     #Decrypt the payload
     decpayload = enc.decrypt(bytes(epayload))
+    seq = int.from_bytes(seq_arr, byteorder='little')
     od['seq']=seq
-    od['magic']=magic
+    od['source']=source
     od['encpayload']=epayload
     od['decpayload']=decpayload
     od['hmac_computed']=hmac_computed


### PR DESCRIPTION
Fixed the length of SEQ (3 bytes) and source (2 bytes). This fixes decryption for packets sent from addresses other than 32768 (such as packets sent from devices instead of an app). Changed the name of 'magic' in decrypt_packet to 'source', which is a breaking change if anyone was using magic.

Fixes #27 